### PR TITLE
Bring back CUDA check.

### DIFF
--- a/share/configure.ac
+++ b/share/configure.ac
@@ -144,6 +144,20 @@ if test x$openmp = xtrue; then
   AC_OPENMP
 fi
 
+# Thrust backend
+if test x$cuda = xtrue; then
+  AC_DEFINE([THRUST_DEVICE_SYSTEM], [THRUST_DEVICE_SYSTEM_CUDA])
+else
+  AC_DEFINE([THRUST_DEVICE_SYSTEM], [THRUST_DEVICE_SYSTEM_CPP])
+fi
+if test x$openmp = xtrue; then
+  AC_DEFINE([THRUST_HOST_SYSTEM], [THRUST_HOST_SYSTEM_OMP])
+else
+  AC_DEFINE([THRUST_HOST_SYSTEM], [THRUST_HOST_SYSTEM_CPP])
+fi
+# ^ OpenMP in Thrust 1.6 very slow, but seems to have been rectified in
+#   Thrust 1.7, so its OpenMP backend has been re-enabled.
+
 # Checks of programs
 if test x$mpi = xtrue; then
     if test x$vampir = xtrue; then


### PR DESCRIPTION
Removed in https://github.com/libbi/LibBi/commit/687f04e94d61771aa9bebcc56b7272b6887b8f3a but without it including the thrust headers might fail if CUDA is not installed.