### PR TITLE
Only search CUDA_ROOT subdirectories if it is set

### DIFF
--- a/share/configure.ac
+++ b/share/configure.ac
@@ -110,8 +110,12 @@ AC_ARG_ENABLE([gperftools],
 # Add standard CUDA directories
 #if test x$cuda = xtrue; then
 # ^ don't test, may be using Thrust bundled with CUDA, even for host
-    CPPFLAGS="$CPPFLAGS -I/usr/local/cuda/include -I$CUDA_ROOT/include"
-    LDFLAGS="$LDFLAGS -L$CUDA_ROOT/lib64 -L$CUDA_ROOT/lib -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib -Wl,-rpath,$CUDA_ROOT/lib64 -Wl,-rpath,$CUDA_ROOT/lib -Wl,-rpath,/usr/local/cuda/lib64 -Wl,-rpath,/usr/local/cuda/lib"
+if test x$CUDA_ROOT != x; then
+  CPPFLAGS="$CPPFLAGS -I$CUDA_ROOT/include -DHAVE_CUBLAS" # -DHAVE_CUBLAS needed for MAGMA 1.4
+  LDFLAGS="$LDFLAGS -L$CUDA_ROOT/lib64 -L$CUDA_ROOT/lib -Wl,-rpath,$CUDA_ROOT/lib64 -Wl,-rpath,$CUDA_ROOT/lib"
+fi
+CPPFLAGS="$CPPFLAGS -I/usr/local/cuda/include"
+LDFLAGS="$LDFLAGS -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib -Wl,-rpath,/usr/local/cuda/lib64 -Wl,-rpath,/usr/local/cuda/lib"
 #fi
 
 # Compilers etc


### PR DESCRIPTION
Without this, /lib and /lib64 get pulled in if CUDA_ROOT is not set, which can lead to conflicts.