### PR TITLE
Discrete probability distributions: Poisson and negative binomial

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -34,8 +34,10 @@ lib/Bi/Action/inclusive_scan.pm
 lib/Bi/Action/inverse_gamma.pm
 lib/Bi/Action/log_gaussian.pm
 lib/Bi/Action/log_normal.pm
+lib/Bi/Action/negbin.pm
 lib/Bi/Action/normal.pm
 lib/Bi/Action/ode_.pm
+lib/Bi/Action/poisson.pm
 lib/Bi/Action/pdf.pm
 lib/Bi/Action/std_.pm
 lib/Bi/Action/transpose.pm
@@ -631,7 +633,9 @@ share/tt/cpp/action/inclusive_scan.hpp.tt
 share/tt/cpp/action/inverse_gamma.hpp.tt
 share/tt/cpp/action/misc/footer.hpp.tt
 share/tt/cpp/action/misc/header.hpp.tt
+share/tt/cpp/action/negbin.hpp.tt
 share/tt/cpp/action/ode_.hpp.tt
+share/tt/cpp/action/poisson.hpp.tt
 share/tt/cpp/action/pdf.hpp.tt
 share/tt/cpp/action/std_.hpp.tt
 share/tt/cpp/action/transpose.hpp.tt

--- a/lib/Bi/Action/negbin.pm
+++ b/lib/Bi/Action/negbin.pm
@@ -1,0 +1,90 @@
+=head1 NAME
+
+negbin - Negative binomial distribution.
+
+=head1 SYNOPSIS
+
+    x ~ negbin()
+    x ~ negbin(1.0, 2.0)
+    x ~ poisson(mean = 1.0, shape = 2.0)
+
+=head1 DESCRIPTION
+
+A C<negbin> action specifies that a variable is distributed according to
+a negative binomial distribution the given C<mean> and C<shape> parameters.
+Note that the implementation will evaluate densities for any (not necessarily
+integer) x. It is left to the user to ensure consistency (e.g., using this only
+with integer observations).
+
+
+=cut
+
+package Bi::Action::negbin;
+
+use parent 'Bi::Action';
+use warnings;
+use strict;
+
+=head1 PARAMETERS
+
+=over 4
+
+=item C<mean> (position 0, default 1.0)
+
+Mean parameter of the distribution.
+
+=item C<shape> (position 1, default 1.0)
+
+Shape parameter of the distribution.
+
+=back
+
+=cut
+our $ACTION_ARGS = [
+  {
+    name => 'mean',
+    positional => 1,
+    default => 1.0
+  },
+  {
+    name => 'shape',
+    positional => 1,
+    default => 1.0
+  },
+];
+
+sub validate {
+    my $self = shift;
+    
+    Bi::Action::validate($self);
+    $self->process_args($ACTION_ARGS);
+    $self->ensure_op('~');
+    $self->ensure_scalar('mean');
+    $self->ensure_scalar('shape');
+
+    unless ($self->get_left->get_shape->compat($self->get_shape)) {
+    	die("incompatible sizes on left and right sides of action.\n");
+    }
+
+    $self->set_parent('pdf_');
+    $self->set_can_combine(1);
+    $self->set_unroll_args(0);
+}
+
+sub mean {
+    my $self = shift;
+
+    my $mean = $self->get_named_arg('mean');
+
+    return $mean;
+}
+
+1;
+
+=head1 AUTHOR
+
+Sebastian Funk <sebastian.funk@lshtm.ac.uk>
+
+=head1 VERSION
+
+$Rev$ $Date$

--- a/lib/Bi/Action/poisson.pm
+++ b/lib/Bi/Action/poisson.pm
@@ -1,0 +1,78 @@
+=head1 NAME
+
+poisson - Poisson distribution.
+
+=head1 SYNOPSIS
+
+    x ~ poisson()
+    x ~ poisson(1.0)
+    x ~ poisson(rate = 2.0)
+
+=head1 DESCRIPTION
+
+A C<poisson> action specifies that a variable is Poisson distributed according to
+the given C<rate> parameter. Note that the implementation will evaluate
+densities for any (not necessarily integer) x. It is left to the user to ensure
+consistency (e.g., using this only with integer observations).
+
+=cut
+
+package Bi::Action::poisson;
+
+use parent 'Bi::Action';
+use warnings;
+use strict;
+
+=head1 PARAMETERS
+
+=over 4
+
+=item C<rate> (position 0, default 1.0)
+
+Rate parameter of the distribution.
+
+=back
+
+=cut
+our $ACTION_ARGS = [
+  {
+    name => 'rate',
+    positional => 1,
+    default => 1.0
+  }
+];
+
+sub validate {
+    my $self = shift;
+    
+    Bi::Action::validate($self);
+    $self->process_args($ACTION_ARGS);
+    $self->ensure_op('~');
+    $self->ensure_scalar('rate');
+
+    unless ($self->get_left->get_shape->compat($self->get_shape)) {
+    	die("incompatible sizes on left and right sides of action.\n");
+    }
+
+    $self->set_parent('pdf_');
+    $self->set_can_combine(1);
+    $self->set_unroll_args(0);
+}
+
+sub mean {
+    my $self = shift;
+
+    my $mean = $self->get_named_arg('rate');
+
+    return $mean;
+}
+
+1;
+
+=head1 AUTHOR
+
+Sebastian Funk <sebastian.funk@lshtm.ac.uk>
+
+=head1 VERSION
+
+$Rev$ $Date$

--- a/share/configure.ac
+++ b/share/configure.ac
@@ -239,6 +239,7 @@ AC_CHECK_HEADERS([\
     boost/random/gamma_distribution.hpp \
     boost/random/mersenne_twister.hpp \
     boost/random/normal_distribution.hpp \
+    boost/random/poisson_distribution.hpp \
     boost/random/uniform_int.hpp \
     boost/random/uniform_real.hpp \
     boost/random/variate_generator.hpp \

--- a/share/src/bi/cuda/random/RandomGPU.cuh
+++ b/share/src/bi/cuda/random/RandomGPU.cuh
@@ -45,6 +45,17 @@ void bi::RandomGPU::gammas(Random& rng, V1 x,
   CUDA_CHECK;
 }
 
+template<class V1>
+void bi::RandomGPU::poissons(Random& rng, V1 x,
+    const typename V1::value_type lambda) {
+  dim3 Db, Dg;
+  Db.x = bi::min(x.size(), deviceIdealThreadsPerBlock());
+  Dg.x = (bi::min(x.size(), deviceIdealThreads()) + Db.x - 1) / Db.x;
+
+  kernelPoissons<<<Dg,Db>>>(rng.devRngs, x, lambda);
+  CUDA_CHECK;
+}
+
 template<class V1, class V2>
 void bi::RandomGPU::multinomials(Random& rng, const V1 lps, V2 xs) {
   BI_ERROR_MSG(false, "Not implemented on device");

--- a/share/src/bi/cuda/random/RandomGPU.hpp
+++ b/share/src/bi/cuda/random/RandomGPU.hpp
@@ -49,6 +49,13 @@ struct RandomGPU {
       1.0, const typename V1::value_type beta = 1.0);
 
   /**
+   * @copydoc Random::poissons
+   */
+  template<class V1>
+  static void poissons(Random& rng, V1 x, const typename V1::value_type labmda =
+                     1.0);
+
+  /**
    * @copydoc Random::gammas
    */
   template<class V1>

--- a/share/src/bi/cuda/random/RandomKernel.cuh
+++ b/share/src/bi/cuda/random/RandomKernel.cuh
@@ -118,4 +118,18 @@ CUDA_FUNC_GLOBAL void bi::kernelGammas(curandStateSA rng, V1 x,
   rng.store(q, rng1.r);
 }
 
+template<class V1>
+CUDA_FUNC_GLOBAL void bi::kernelPoissons(curandStateSA rng, V1 x,
+    const typename V1::value_type lambda) {
+  const int q = blockIdx.x*blockDim.x + threadIdx.x;
+  const int Q = blockDim.x*gridDim.x;
+
+  RngGPU rng1;
+  rng.load(q, rng1.r);
+  for (int p = q; p < x.size(); p += Q) {
+    x(p) = rng1.poisson(lambda);
+  }
+  rng.store(q, rng1.r);
+}
+
 #endif

--- a/share/src/bi/cuda/random/RngGPU.cuh
+++ b/share/src/bi/cuda/random/RngGPU.cuh
@@ -137,4 +137,12 @@ inline T1 bi::RngGPU::gamma(const T1 alpha, const T1 beta) {
   return scale*dv;
 }
 
+inline float bi::RngGPU::poisson(const float lambda) {
+  return curand_poisson(&r, lambda);
+}
+
+inline double bi::RngGPU::poisson(const double lambda) {
+  return curand_poisson(&r);
+}
+
 #endif

--- a/share/src/bi/host/random/RandomHost.hpp
+++ b/share/src/bi/host/random/RandomHost.hpp
@@ -47,6 +47,13 @@ struct RandomHost {
       1.0, const typename V1::value_type beta = 1.0);
 
   /**
+   * @copydoc Random::poissons
+   */
+  template<class V1>
+  static void poissons(Random& rng, V1 x, const typename V1::value_type lambda =
+                     1.0);
+
+  /**
    * @copydoc Random::betas
    */
   template<class V1>

--- a/share/src/bi/host/random/RngHost.hpp
+++ b/share/src/bi/host/random/RngHost.hpp
@@ -66,6 +66,12 @@ public:
   T1 gamma(const T1 alpha = 1.0, const T1 beta = 1.0);
 
   /**
+   * @copydoc Random::poisson
+   */
+  template<class T1>
+  T1 poisson(const T1 lambda = 1.0);
+
+  /**
    * Random number generator type.
    */
   typedef boost::mt19937 rng_type;
@@ -84,6 +90,7 @@ public:
 #include "boost/random/uniform_real.hpp"
 #include "boost/random/normal_distribution.hpp"
 #include "boost/random/gamma_distribution.hpp"
+#include "boost/random/poisson_distribution.hpp"
 #include "boost/random/variate_generator.hpp"
 
 #include "thrust/binary_search.h"
@@ -158,6 +165,19 @@ inline T1 bi::RngHost::gamma(const T1 alpha, const T1 beta) {
   boost::variate_generator<rng_type&, dist_type> gen(rng, dist);
 
   return beta*gen();
+}
+
+template<class T1>
+inline T1 bi::RngHost::poisson(const T1 lambda) {
+  /* pre-condition */
+  BI_ASSERT(lambda > 0.0);
+
+  typedef boost::poisson_distribution<int,T1> dist_type;
+
+  dist_type dist(lambda);
+  boost::variate_generator<rng_type&, dist_type> gen(rng, dist);
+
+  return static_cast<T1>(gen());
 }
 
 #endif

--- a/share/src/bi/pdf/primitive.hpp
+++ b/share/src/bi/pdf/primitive.hpp
@@ -225,4 +225,68 @@ void bi::inverse_gamma_log_densities(const M1 Z, const T1 alpha, const T1 beta,
   }
 }
 
+template<class M1, class T1, class V1>
+void bi::poisson_densities(const M1 Z, const T1 lambda,
+                                 V1 p, const bool clear) {
+  /* pre-condition */
+  BI_ASSERT(Z.size1() == p.size());
+
+  op_elements(vec(Z), vec(Z), poisson_density_functor<T1>(lambda));
+  if (clear) {
+    prod_columns(Z, p);
+  } else {
+    typename sim_temp_vector<V1>::type p1(p.size());
+    prod_columns(Z, p1);
+    mul_elements(p, p1, p);
+  }
+}
+
+template<class M1, class T1, class V1>
+void bi::poisson_log_densities(const M1 Z, const T1 lambda,
+                                     V1 p, const bool clear) {
+  /* pre-condition */
+  BI_ASSERT(Z.size1() == p.size());
+
+  op_elements(vec(Z), vec(Z), poisson_log_density_functor<T1>(lambda));
+  if (clear) {
+    sum_columns(Z, p);
+  } else {
+    typename sim_temp_vector<V1>::type p1(p.size());
+    sum_columns(Z, p1);
+    add_elements(p, p1, p);
+  }
+}
+
+template<class M1, class T1, class V1>
+void bi::negbin_densities(const M1 Z, const T1 mean, const T1 shape,
+                                 V1 p, const bool clear) {
+  /* pre-condition */
+  BI_ASSERT(Z.size1() == p.size());
+
+  op_elements(vec(Z), vec(Z), negbin_density_functor<T1>(mean, shape));
+  if (clear) {
+    prod_columns(Z, p);
+  } else {
+    typename sim_temp_vector<V1>::type p1(p.size());
+    prod_columns(Z, p1);
+    mul_elements(p, p1, p);
+  }
+}
+
+template<class M1, class T1, class V1>
+void bi::negbin_log_densities(const M1 Z, const T1 mean, const T1 shape,
+                                     V1 p, const bool clear) {
+  /* pre-condition */
+  BI_ASSERT(Z.size1() == p.size());
+
+  op_elements(vec(Z), vec(Z), negbin_log_density_functor<T1>(mean, shape));
+  if (clear) {
+    sum_columns(Z, p);
+  } else {
+    typename sim_temp_vector<V1>::type p1(p.size());
+    sum_columns(Z, p1);
+    add_elements(p, p1, p);
+  }
+}
+
 #endif

--- a/share/src/bi/random/generic.hpp
+++ b/share/src/bi/random/generic.hpp
@@ -101,6 +101,22 @@ template<class R, class T1>
 CUDA_FUNC_BOTH T1 truncated_gaussian(R& rng, const T1 lower, const T1 upper,
     const T1 mu = 0.0, const T1 sigma = 1.0);
 
+/**
+ * Generate a random number from a negative binomial distribution with given
+ * parameters.
+ *
+ * @tparam R Random number generator type.
+ * @tparam T1 Scalar type.
+ *
+ * @param[in,out] rng Random number generator.
+ * @param alpha Shape.
+ * @param beta Scale.
+ *
+ * @return The random number.
+ */
+template<class R, class T1>
+CUDA_FUNC_BOTH T1 negbin(R& rng, const T1 mu = 1.0, const T1 k = 1.0);
+
 }
 
 template<class R, class T1>
@@ -158,6 +174,20 @@ T1 bi::truncated_gaussian(R& rng, const T1 lower, const T1 upper, const T1 mu,
   } else do {
     u = rng.gaussian(mu, sigma);
   } while (u < lower || u > upper);
+
+  return u;
+}
+
+template<class R, class T1>
+inline T1 bi::negbin(R& rng, const T1 mu, const T1 k) {
+  /* pre-condition */
+  BI_ASSERT(mu > static_cast<T1>(0.0) && k > static_cast<T1>(0.0));
+
+  T1 u;
+
+  const T1 x = rng.gamma(k, mu/k);
+
+  u = static_cast<T1>(rng.poisson(x));
 
   return u;
 }

--- a/share/tt/cpp/action/negbin.hpp.tt
+++ b/share/tt/cpp/action/negbin.hpp.tt
@@ -1,0 +1,90 @@
+[%
+## @file
+##
+## @author Sebastian Funk <sebastian.funk@lshtm.ac.uk>
+## $Rev$
+## $Date$
+%]
+
+[%-
+mean = action.get_named_arg('mean');
+shape = action.get_named_arg('shape');
+%]
+
+[%-PROCESS action/misc/header.hpp.tt-%]
+
+/**
+ * Action: [% action.get_name %].
+ */
+class [% class_name %] {
+public:
+  [% std_action %]
+
+  [% declare_action_static_function('simulate') %]
+  [% declare_action_static_function('sample') %]
+  [% declare_action_static_function('logdensity') %]
+  [% declare_action_static_function('maxlogdensity') %]
+};
+
+#include "bi/pdf/functor.hpp"
+#include "bi/random/generic.hpp"
+
+[% std_action_static_function('simulate') %]
+
+[% sig_action_static_function('sample') %] {
+  [% alias_dims(action) %]
+  [% fetch_parents(action) %]
+  [% offset_coord(action) %]
+
+  real me = [% mean.to_cpp %];
+  real sh = [% shape.to_cpp %];
+  real u = bi::negbin(rng, me, sh);
+  
+  [% put_output(action, 'u') %]
+}
+
+[% sig_action_static_function('logdensity') %] {
+  [% alias_dims(action) %]
+  [% fetch_parents(action) %]
+  [% offset_coord(action) %]
+
+  real me = [% mean.to_cpp %];
+  real sh = [% shape.to_cpp %];
+  
+  real xy = pax.template fetch_alt<target_type>(s, p, cox_.index());
+
+  bi::negbin_log_density_functor<T1> f(me, sh);
+  lp += f(xy);
+
+  [% put_output(action, 'xy') %]
+}
+
+[% sig_action_static_function('maxlogdensity') %] {
+  [% alias_dims(action) %]
+  [% fetch_parents(action) %]
+  [% offset_coord(action) %]
+
+  real me = [% mean.to_cpp %];
+  real sh = [% shape.to_cpp %];
+
+  real xy = pax.template fetch_alt<target_type>(s, p, cox_.index());
+  
+  [% IF mean.is_common && shape.is_common %]
+  bi::negbin_log_density_functor<T1> f(me, sh);
+  if (me > BI_REAL(0.0) && sh > BI_REAL(0.0)) {
+    if (sh > BI_REAL(1.0)) {
+    	lp += f(bi::floor(me * (sh - 1) / sh));
+    } else {
+      lp += 0.0;
+    }
+  } else {
+    lp = BI_INF;
+  }
+  [% ELSE %]
+  lp = BI_INF;
+  [% END %]
+
+  [% put_output(action, 'xy') %]
+}
+
+[%-PROCESS action/misc/footer.hpp.tt-%]

--- a/share/tt/cpp/action/poisson.hpp.tt
+++ b/share/tt/cpp/action/poisson.hpp.tt
@@ -1,0 +1,81 @@
+[%
+## @file
+##
+## @author Sebastian Funk <sebastian.funk@lshtm.ac.uk>
+## $Rev$
+## $Date$
+%]
+
+[%-
+rate = action.get_named_arg('rate');
+%]
+
+[%-PROCESS action/misc/header.hpp.tt-%]
+
+/**
+ * Action: [% action.get_name %].
+ */
+class [% class_name %] {
+public:
+  [% std_action %]
+
+  [% declare_action_static_function('simulate') %]
+  [% declare_action_static_function('sample') %]
+  [% declare_action_static_function('logdensity') %]
+  [% declare_action_static_function('maxlogdensity') %]
+};
+
+#include "bi/pdf/functor.hpp"
+
+[% std_action_static_function('simulate') %]
+
+[% sig_action_static_function('sample') %] {
+  [% alias_dims(action) %]
+  [% fetch_parents(action) %]
+  [% offset_coord(action) %]
+
+  real ra = [% rate.to_cpp %];
+  real u = static_cast<real>(rng.poisson(ra));
+  
+  [% put_output(action, 'u') %]
+}
+
+[% sig_action_static_function('logdensity') %] {
+  [% alias_dims(action) %]
+  [% fetch_parents(action) %]
+  [% offset_coord(action) %]
+
+  real ra = [% rate.to_cpp %];
+  
+  real xy = pax.template fetch_alt<target_type>(s, p, cox_.index());
+
+  bi::poisson_log_density_functor<T1> f(ra);
+  lp += f(xy);
+
+  [% put_output(action, 'xy') %]
+}
+
+[% sig_action_static_function('maxlogdensity') %] {
+  [% alias_dims(action) %]
+  [% fetch_parents(action) %]
+  [% offset_coord(action) %]
+
+  real ra = [% rate.to_cpp %];
+
+  real xy = pax.template fetch_alt<target_type>(s, p, cox_.index());
+  
+  [% IF rate.is_common %]
+  bi::poisson_log_density_functor<T1> f(ra);
+  if (ra > BI_REAL(0.0)) {
+  	lp += f(bi::floor(ra));
+  } else {
+    lp = BI_INF;
+  }
+  [% ELSE %]
+  lp = BI_INF;
+  [% END %]
+
+  [% put_output(action, 'xy') %]
+}
+
+[%-PROCESS action/misc/footer.hpp.tt-%]


### PR DESCRIPTION
Two discrete probability distributions: Poisson and negative binomial. This uses the Poisson distribution as implemented in boost and cudarng, and a Poisson/gamma mixture for the negative binomial.

This is useful for modelling discrete count data. I guess it could also serve to implement discrete event simulation (e.g., fixed-tau leaping).