### PR TITLE
fixed model name mismatch warning

### DIFF
--- a/lib/Bi/FrontEnd.pm
+++ b/lib/Bi/FrontEnd.pm
@@ -65,6 +65,7 @@ use Carp;
 use Carp::Assert;
 use Getopt::Long qw(:config pass_through no_auto_abbrev no_ignore_case);
 use File::Path;
+use File::Basename;
 use IO::File;
 use Fcntl qw(:flock);
 
@@ -153,7 +154,7 @@ sub client {
         	my $parser = new Bi::Parser;
         	$model = $parser->parse($fh);
         	$fh->close;
-        	if ($model->get_name . '.bi' ne $self->{_model_file}) {
+          if ($model->get_name . '.bi' ne basename($self->{_model_file})) {
             	warn("model name does not match model file name\n");
         	}
     	}


### PR DESCRIPTION
Stops warning if file has the same name as the model but is in a different directoy.