### PR TITLE
Fix Poisson distribution

### DIFF
--- a/share/src/bi/pdf/functor.hpp
+++ b/share/src/bi/pdf/functor.hpp
@@ -241,7 +241,8 @@ struct poisson_log_density_functor: public std::unary_function<T,T> {
 
   CUDA_FUNC_BOTH
   T operator()(const T& x) const {
-    return x * log(lambda) - lambda + lgamma(x + 1);
+    if (lambda == 0) return (x == 0 ? 0 : -BI_INF);
+    else return x * log(lambda) - lambda - lgamma(x + 1);
   }
 };
 


### PR DESCRIPTION
1) corrects a sign

2) allows to sample from a Poisson with lambda=0; this appears to be convention in stochastic modelling (at least it's the case in R); generally, we don't want crash if numerical (im-)precision creates this situation.