### PR TITLE
Allow negative binomial with mean zero

### DIFF
--- a/share/src/bi/pdf/functor.hpp
+++ b/share/src/bi/pdf/functor.hpp
@@ -281,7 +281,8 @@ struct negbin_log_density_functor: public std::unary_function<T,T> {
 
   CUDA_FUNC_BOTH
   T operator()(const T& x) const {
-    return lgamma(k + x + 1) - lgamma(x + 1) + x * logY - logZ;
+    if (mu == 0) return (x == 0 ? 0 : -BI_INF);
+    else return lgamma(k + x + 1) - lgamma(x + 1) + x * logY - logZ;
   }
 };
 

--- a/share/src/bi/random/generic.hpp
+++ b/share/src/bi/random/generic.hpp
@@ -181,13 +181,17 @@ T1 bi::truncated_gaussian(R& rng, const T1 lower, const T1 upper, const T1 mu,
 template<class R, class T1>
 inline T1 bi::negbin(R& rng, const T1 mu, const T1 k) {
   /* pre-condition */
-  BI_ASSERT(mu > static_cast<T1>(0.0) && k > static_cast<T1>(0.0));
+  BI_ASSERT(mu >= static_cast<T1>(0.0) && k >= static_cast<T1>(0.0));
 
   T1 u;
 
-  const T1 x = rng.gamma(k, mu/k);
+  if (mu > 0) {
+    const T1 x = rng.gamma(k, mu/k);
 
-  u = static_cast<T1>(rng.poisson(x));
+    u = static_cast<T1>(rng.poisson(x));
+  } else {
+    u = 0;
+  }
 
   return u;
 }


### PR DESCRIPTION
This is not strictly statistically correct, but deals with any zeroes arising from (lack of) machine precision.