### PR TITLE
closed bounds on truncated_gaussian

### DIFF
--- a/share/src/bi/random/generic.hpp
+++ b/share/src/bi/random/generic.hpp
@@ -146,7 +146,7 @@ T1 bi::lower_truncated_gaussian(R& rng, const T1 lower, const T1 mu,
   T1 u;
   do {
     u = rng.gaussian(mu, sigma);
-  } while (u < lower);
+  } while (u <= lower);
 
   return u;
 }
@@ -157,7 +157,7 @@ T1 bi::upper_truncated_gaussian(R& rng, const T1 upper, const T1 mu,
   T1 u;
   do {
     u = rng.gaussian(mu, sigma);
-  } while (u > upper);
+  } while (u >= upper);
 
   return u;
 }
@@ -173,7 +173,7 @@ T1 bi::truncated_gaussian(R& rng, const T1 lower, const T1 upper, const T1 mu,
     u = upper;
   } else do {
     u = rng.gaussian(mu, sigma);
-  } while (u < lower || u > upper);
+  } while (u <= lower || u >= upper);
 
   return u;
 }


### PR DESCRIPTION
This changes bounds on truncated_gaussian from open to closed, to be consistent with the manual.