### PR TITLE
allow input for state and noise vars

### DIFF
--- a/lib/Bi/Client.pm
+++ b/lib/Bi/Client.pm
@@ -121,9 +121,13 @@ must be at least the number of samples.
 
 Index along the C<ns> dimension of C<--input-file> to use.
 
-=item C<--input-np> (default 0)
+=item C<--input-np> (default -1)
 
-Index along the C<np> dimension of C<--input-file> to use.
+Index along the C<np> dimension of C<--input-file> to use. -1 indicates that,
+when state variables are read from the input file, rather than initialising all
+state variables identically, the C<np> dimension is used to initialise them all
+differently. The size of the C<np> dimension must be at least the number of
+samples.
 
 =item C<--obs-ns> (default 0)
 
@@ -241,7 +245,7 @@ our @CLIENT_OPTIONS = (
     {
       name => 'input-np',
       type => 'int',
-      default => 0
+      default => -1
     },
     {
       name => 'obs-ns',

--- a/share/src/bi/simulator/Forcer.hpp
+++ b/share/src/bi/simulator/Forcer.hpp
@@ -100,6 +100,8 @@ inline void bi::Forcer<IO1,CL>::update(const int k, State<B,L>& s) {
     in.read(k, F_VAR, s.get(F_VAR));
     cache.set(k, vec(s.get(F_VAR)));
   }
+  in.read(k, D_VAR, s.get(D_VAR));
+  in.read(k, R_VAR, s.get(R_VAR));
   s.setLastInputTime(in.getTime(k));
 }
 
@@ -112,6 +114,8 @@ inline void bi::Forcer<IO1,CL>::update0(State<B,L>& s) {
     in.read0(F_VAR, s.get(F_VAR));
     cache0.set(0, vec(s.get(F_VAR)));
   }
+  in.read0(D_VAR, s.get(D_VAR));
+  in.read0(R_VAR, s.get(R_VAR));
 }
 
 template<class IO1, bi::Location CL>


### PR DESCRIPTION
This might be philosophically unacceptable but it does allows to have inputs that vary by time _and_ trajectory.